### PR TITLE
Fix globstring to match files in test subdirs

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./node_modules/mocha/bin/mocha ./test/setup.coffee \
-  ./src/**/test/*.coffee \
+  ./src/**/test/**/*.coffee \
   --reporter spec \
   --ui bdd \
   --debug \


### PR DESCRIPTION
It wasn't matching 1 level deep test folders, this PR solves that issue.

Before it wasn't matching `./src/components/foocomponent/test/index.coffee` it was only selecting subfolders of `src` component and wasn't going into that folder's subfolders.
