### PR TITLE
KDLoader

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "spin.js": "^2.3.1"
   }
 }

--- a/src/components/loader/index.coffee
+++ b/src/components/loader/index.coffee
@@ -1,0 +1,40 @@
+React = require 'react'
+curry = require 'classnames'
+
+KDComponent = require '../../core/component'
+
+Spinner = require 'spin.js'
+
+module.exports = class KDLoader extends KDComponent
+
+  @propTypes    :
+    options     : React.PropTypes.shape
+      scale     : React.PropTypes.number
+      lines     : React.PropTypes.number
+      length    : React.PropTypes.number
+      width     : React.PropTypes.number
+      radius    : React.PropTypes.number
+      corners   : React.PropTypes.number
+      rotate    : React.PropTypes.number
+      direction : React.PropTypes.oneOf([1 -1])
+      color     : React.PropTypes.string
+      speed     : React.PropTypes.number
+      trail     : React.PropTypes.number
+      shadow    : React.PropTypes.bool
+      hwaccell  : React.PropTypes.bool
+      className : React.PropTypes.string
+      zIndex    : React.PropTypes.number
+      top       : React.PropTypes.string
+      left      : React.PropTypes.string
+
+
+  componentDidMount: ->
+
+    new Spinner(@props.options).spin @refs.spinner.getDOMNode()
+
+
+  render: ->
+    <div className={curry 'Loader', @props.className}>
+      <span ref="spinner" className="Loader-Spinner" />
+    </div>
+

--- a/src/components/loader/test/index.coffee
+++ b/src/components/loader/test/index.coffee
@@ -1,0 +1,48 @@
+React         = require 'react/addons'
+KDLoader      = require '../'
+{ expect }    = require 'chai'
+{ TestUtils } = React.addons
+
+{ $, injectLifecycleHooks } = require '../../../../test/testutils'
+
+describe 'KDLoader', ->
+
+  it 'works', ->
+
+    expect(typeof KDLoader).to.equal 'function'
+
+
+  describe 'props', ->
+
+    it 'has default css className of `Loader`', ->
+
+      loader = TestUtils.renderIntoDocument(
+        <KDLoader className="ExtraClass" />
+      )
+
+      domNode = React.findDOMNode loader
+      expect($.classList domNode).to.contain 'Loader'
+      expect($.classList domNode).to.contain 'ExtraClass'
+
+
+  describe 'Spinner', ->
+
+    injector = null
+    beforeEach -> injector = injectLifecycleHooks KDLoader
+    afterEach -> injector.restore()
+
+    it 'shows a spinner after component got mounted', (done) ->
+
+      injector.on 'componentDidMount', (_loader) ->
+
+        spinner = $ _loader, '.Loader-Spinner'
+        domNode = spinner.getDOMNode()
+
+        expect(domNode.children.length).to.equal 1
+        expect(domNode.children[0].className).to.equal 'spinner'
+
+        done()
+
+      loader = TestUtils.renderIntoDocument(<KDLoader />)
+
+

--- a/test/testutils.coffee
+++ b/test/testutils.coffee
@@ -17,6 +17,7 @@ $ = (component, selector) ->
   else
     findRenderedDOMComponentWithTag component, selector
 
+
 ###*
  * Returns the classlist of given dom node.
  *
@@ -27,6 +28,7 @@ $.classList = (domNode) -> domNode.className.split ' '
 
 noop = ->
 noop.type = 'noop'
+
 
 ###*
  * Takes a component and injects an event emitter into lifecycle methods to be
@@ -78,7 +80,6 @@ injectLifecycleHooks = (Component) ->
   _on = (args...) -> emitter.on args...
 
   return { restore, on: _on }
-
 
 
 module.exports = TestUtils = {


### PR DESCRIPTION
Simple wrapper around `spin.js` module.

`KDLoader` accepts an `options` prop to be passed onto `spin.js` constructor.

It doesn't have any state, it just renders loader.
#### Usage

``` cjsx
class FooComponent extends KDComponent
  render: ->
    <KDLoader options={{ scale: 2, length: 0, ... }} /> # options is what is passed to spin.js constructor.
```

---

Also this PR introduces `TestHelpers` especially the `injectLifecycleHooks` part is important, 
- it redefines given component Class's [lifecycle methods](https://facebook.github.io/react/docs/component-specs.html#lifecycle-methods)
- injects an event emitter so that we can hook into those lifecycle methods, and make assertions there, an example can be seen [here](https://github.com/koding/kd-react/pull/4/files#diff-fc8fdabe149ae55db2cda02a34674ab5R28).
