### PR TITLE
Apply coffee-reactify transform for browserify builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koding/kd-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React components of KD framework views",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Browserify doesn't apply transforms to `node_modules` except the transforms are not specified in `package.json`.
